### PR TITLE
'open' access control for 'var nib'

### DIFF
--- a/MessengerKit/Input/Styles/iMessage/MSGImessageInputView.swift
+++ b/MessengerKit/Input/Styles/iMessage/MSGImessageInputView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 open class MSGImessageInputView: MSGInputView {
     
-    override public class var nib: UINib? {
+    override open class var nib: UINib? {
         return UINib(nibName: "MSGImessageInputView",
                      bundle: MessengerKit.bundle)
     }


### PR DESCRIPTION
Made the nib open to allow its extension outside the module.