### PR TITLE
Fix link style & Add underline option

### DIFF
--- a/MessengerKit/Collection View/Cells/Text/Travamigos/MSGTravCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Text/Travamigos/MSGTravCollectionViewCell.swift
@@ -26,8 +26,8 @@ open class MSGTravCollectionViewCell: MSGMessageCell {
     override open var style: MSGMessengerStyle? {
         didSet {
             guard let message = message, let style = style as? MSGTravamigosStyle else { return }
-            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: style.outgoingLinkColor]
-            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: style.outgoingLinkColor]
+            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
+            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
             bubble.font = style.font
             bubble.textColor = message.user.isSender ? style.outgoingTextColor : style.incomingTextColor
             bubble.gradientLayer.colors = message.user.isSender ? style.outgoingGradient : style.incomingGradient

--- a/MessengerKit/Collection View/Cells/Text/Travamigos/MSGTravCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Text/Travamigos/MSGTravCollectionViewCell.swift
@@ -26,8 +26,11 @@ open class MSGTravCollectionViewCell: MSGMessageCell {
     override open var style: MSGMessengerStyle? {
         didSet {
             guard let message = message, let style = style as? MSGTravamigosStyle else { return }
-            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
-            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
+            bubble.linkTextAttributes = [
+                NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor,
+                NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor,
+                NSAttributedString.Key.underlineStyle: message.user.isSender ? style.outgoingLinkUnderlineStyle : style.incomingLinkUnderlineStyle
+            ]
             bubble.font = style.font
             bubble.textColor = message.user.isSender ? style.outgoingTextColor : style.incomingTextColor
             bubble.gradientLayer.colors = message.user.isSender ? style.outgoingGradient : style.incomingGradient

--- a/MessengerKit/Collection View/Cells/Text/iMessage/MSGTailCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Text/iMessage/MSGTailCollectionViewCell.swift
@@ -26,8 +26,8 @@ open class MSGTailCollectionViewCell: MSGMessageCell {
     override open var style: MSGMessengerStyle? {
         didSet {
             guard let message = message, let style = style as? MSGIMessageStyle else { return }
-            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: style.outgoingLinkColor]
-            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: style.outgoingLinkColor]
+            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
+            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
             bubble.font = style.font
             bubble.backgroundImageView.tintColor = message.user.isSender ? style.outgoingBubbleColor : style.incomingBubbleColor
             bubble.textColor = message.user.isSender ? style.outgoingTextColor : style.incomingTextColor

--- a/MessengerKit/Collection View/Cells/Text/iMessage/MSGTailCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Text/iMessage/MSGTailCollectionViewCell.swift
@@ -26,8 +26,11 @@ open class MSGTailCollectionViewCell: MSGMessageCell {
     override open var style: MSGMessengerStyle? {
         didSet {
             guard let message = message, let style = style as? MSGIMessageStyle else { return }
-            bubble.linkTextAttributes = [NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
-            bubble.linkTextAttributes = [NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor]
+            bubble.linkTextAttributes = [
+                NSAttributedString.Key.underlineColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor,
+                NSAttributedString.Key.foregroundColor: message.user.isSender ? style.outgoingLinkColor : style.incomingLinkColor,
+                NSAttributedString.Key.underlineStyle: message.user.isSender ? style.outgoingLinkUnderlineStyle : style.incomingLinkUnderlineStyle
+            ]
             bubble.font = style.font
             bubble.backgroundImageView.tintColor = message.user.isSender ? style.outgoingBubbleColor : style.incomingBubbleColor
             bubble.textColor = message.user.isSender ? style.outgoingTextColor : style.incomingTextColor

--- a/MessengerKit/Styles/MSGIMessageStyle.swift
+++ b/MessengerKit/Styles/MSGIMessageStyle.swift
@@ -40,6 +40,10 @@ public struct MSGIMessageStyle: MSGMessengerStyle {
     public var outgoingLinkColor: UIColor = .white
     
     public var incomingLinkColor: UIColor = UIColor(hue:0.58, saturation:0.81, brightness:0.95, alpha:1.00)
+
+    public var outgoingLinkUnderlineStyle: NSNumber = 0
+
+    public var incomingLinkUnderlineStyle: NSNumber = 0
     
     public func size(for message: MSGMessage, in collectionView: UICollectionView) -> CGSize {
         

--- a/MessengerKit/Styles/MSGMessengerStyle.swift
+++ b/MessengerKit/Styles/MSGMessengerStyle.swift
@@ -57,11 +57,17 @@ public protocol MSGMessengerStyle {
     /// Color of links in the outgoing messages
     var outgoingLinkColor: UIColor { get }
     
+    /// Underline style of links on the outgoing messages
+    var outgoingLinkUnderlineStyle: NSNumber { get }
+
     /// The text color of incoming messages
     var incomingTextColor: UIColor { get }
     
     /// Color of links on the incoming messages
     var incomingLinkColor: UIColor { get }
+
+    /// Underline style of links on the incoming messages
+    var incomingLinkUnderlineStyle: NSNumber { get }
 
     /// Calculates the size of the cell for a given message
     ///

--- a/MessengerKit/Styles/MSGTravamigosStyle.swift
+++ b/MessengerKit/Styles/MSGTravamigosStyle.swift
@@ -41,6 +41,10 @@ public struct MSGTravamigosStyle: MSGMessengerStyle {
     
     public var incomingLinkColor: UIColor = UIColor(red:1.00, green:0.30, blue:0.13, alpha:1.00)
     
+    public var outgoingLinkUnderlineStyle: NSNumber = 0
+
+    public var incomingLinkUnderlineStyle: NSNumber = 0
+
     public func size(for message: MSGMessage, in collectionView: UICollectionView) -> CGSize {
         
         var size: CGSize!


### PR DESCRIPTION
The link style option for incoming & outgoing messages were not correct. Only the outgoing option was used. I fixed that in this PR.

Additional I added a style option for control the underline setting for links.