### PR TITLE
Initialize the image in nil so no flicker from the previous image

### DIFF
--- a/MessengerKit/Collection View/Cells/Media/MSGImageCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Media/MSGImageCollectionViewCell.swift
@@ -20,6 +20,7 @@ class MSGImageCollectionViewCell: MSGMessageCell {
                 return
             }
             
+            imageView.image = nil
             if case let MSGMessageBody.image(image) = message.body {
                 imageView.image = image
             } else if case let MSGMessageBody.imageFromUrl(imageUrl) = message.body {

--- a/MessengerKit/Collection View/Cells/Media/MSGImageCollectionViewCell.swift
+++ b/MessengerKit/Collection View/Cells/Media/MSGImageCollectionViewCell.swift
@@ -20,7 +20,6 @@ class MSGImageCollectionViewCell: MSGMessageCell {
                 return
             }
             
-            imageView.image = nil
             if case let MSGMessageBody.image(image) = message.body {
                 imageView.image = image
             } else if case let MSGMessageBody.imageFromUrl(imageUrl) = message.body {
@@ -35,6 +34,7 @@ class MSGImageCollectionViewCell: MSGMessageCell {
     }
     
     private func downloadImage(from url: URL) {
+        imageView.image = nil
         print("Download Started")
         getData(from: url) { data, response, error in
             guard let data = data, error == nil else { return }
@@ -48,7 +48,7 @@ class MSGImageCollectionViewCell: MSGMessageCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+        imageView.image = nil
         imageView.layer.cornerRadius = 18
         imageView.layer.masksToBounds = true
         imageView.isUserInteractionEnabled = true   


### PR DESCRIPTION
When images were added to the conversations, before downloading, the previous image was shown moments previous to the finished download.  Initializing the image in nil before loading the new image fixes the flicker issue.